### PR TITLE
Update run.md

### DIFF
--- a/olympus_mons/run.md
+++ b/olympus_mons/run.md
@@ -116,7 +116,7 @@ source ~/.profile
 
 Finally, you should move the evmosd binary into the cosmovisor/genesis folder.
 ```
-mv $GOPATH/bin/evmosd ~/.evmosd/cosmovisor/genesis/bin
+cp $GOPATH/bin/evmosd ~/.evmosd/cosmovisor/genesis/bin
 ```
 
 ### Download Genesis File


### PR DESCRIPTION
You still need the evmosd to execute the ```evmosd unsafe-reset-all```  Users need to remember to update this binary when there are updates via Cosmovisor.