### PR TITLE
Fix explorer link in testnet Readme

### DIFF
--- a/evmos_9000-3/README.md
+++ b/evmos_9000-3/README.md
@@ -30,7 +30,7 @@ sha256sum genesis.json
 - `evmosd` version: [`v1.0.0-beta1`](https://github.com/tharsis/evmos/releases)
 - Faucet: [faucet.evmos.dev](https://faucet.evmos.dev)
 - EVM explorer: [evm.evmos.dev](https://evm.evmos.dev)
-- Cosmos explorer: [explorer.evmos.dev](https://explorer.evmos.dev)
+- Cosmos explorer: [explorer.evmos.dev](https://testnet.mintscan.io/evmos-testnet)
 
 ## Seeds & Peers
 


### PR DESCRIPTION
**You might want to fix the redirect on https://explorer.evmos.dev instead**, you should update it to forward to the new address:
https://testnet.mintscan.io/evmos-testnet
the old one is 404:
https://testnet.mintscan.io/evmos